### PR TITLE
- Event capture: Guild Created

### DIFF
--- a/libdiscord/include/bot.h
+++ b/libdiscord/include/bot.h
@@ -34,6 +34,7 @@ namespace discord
     std::function<void(emoji&)> m_on_emoji_created;
     std::function<void(emoji&)> m_on_emoji_deleted;
     std::function<void(emoji&)> m_on_emoji_updated;
+	std::function<void(guild&)> m_on_guild_created;
     std::function<void(presence&)> m_on_presence;
     std::function<void(typing_event&)> m_on_typing;
     std::unordered_map<std::string, std::function<void(message_event)>> m_commands;
@@ -115,6 +116,12 @@ namespace discord
      * @param callback The callback to trigger.
      */
     void on_emoji_updated(std::function<void(emoji&)> callback);
+
+	/** Triggered when a guild created event is received.
+	 *
+	 * @param callback The callback to trigger.
+	 */
+	void on_guild_created(std::function<void(guild&)> callback);
 
     /** Triggered when a presence event is received.
      *

--- a/libdiscord/include/connection_state.h
+++ b/libdiscord/include/connection_state.h
@@ -25,13 +25,18 @@ namespace discord
   enum event_type
   {
     Ready,
+	// Messages
     MessageCreated,
     MessageDeleted,
     MessageEdited,
     MessagesBulkDeleted,
+	// Guild
+	GuildCreated,
+	// Emoji
     EmojiCreated,
     EmojiDeleted,
     EmojiEdited,
+	// Misc
     Presence,
     Typing
   };

--- a/libdiscord/include/event/guild_event.h
+++ b/libdiscord/include/event/guild_event.h
@@ -4,6 +4,12 @@
 
 namespace discord
 {
+	class guild_created : public event
+	{
+	public:
+		explicit guild_created(const std::string& token, rapidjson::Value& data);
+	};
+
   class presence_event : public event
   {
   public:

--- a/libdiscord/src/bot.cpp
+++ b/libdiscord/src/bot.cpp
@@ -21,7 +21,7 @@ namespace discord
       {
         if (m_on_ready)
         {
-          m_on_ready();
+			m_on_ready();
         }
         break;
       }
@@ -89,6 +89,15 @@ namespace discord
           }
         }
       }
+	case GuildCreated:
+	  {
+		if(m_on_guild_created)
+		{
+			guild guild(m_conn_state.get(), data);
+			m_on_guild_created(guild);
+		}
+		break;
+	  }
     case Presence:
       {
         if (m_on_presence)
@@ -204,6 +213,11 @@ namespace discord
   void bot::on_emoji_updated(std::function<void(emoji&)> callback)
   {
     m_on_emoji_updated = callback;
+  }
+
+  void bot::on_guild_created(std::function<void(guild&)> callback) 
+  {
+	  m_on_guild_created = callback;
   }
 
   void bot::on_presence(std::function<void(presence&)> callback)

--- a/libdiscord/src/connection_state.cpp
+++ b/libdiscord/src/connection_state.cpp
@@ -414,6 +414,7 @@ namespace discord
     {
       guild new_guild(this, data);
       m_guilds[new_guild.id()] = new_guild;
+	  raise_event(GuildCreated, data);
     }
     else if (event_name == "GUILD_UPDATE")
     {


### PR DESCRIPTION
- Support for GUILD_CREATED event, alternatively serves as a "ready" that has channels and guilds loaded.